### PR TITLE
handle encoded URIs

### DIFF
--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -237,7 +237,7 @@ ConfigurableProxy.prototype.delete_routes = function (req, res, path) {
 ConfigurableProxy.prototype.target_for_req = function (req) {
     // return proxy target for a given url path
     var base_path = (this.host_routing) ? '/' + parse_host(req) : '';
-    var route = this.trie.get(base_path + req.url);
+    var route = this.trie.get(trie.string_to_path(base_path + decodeURIComponent(req.url)));
     if (route) {
         return {
             prefix: route.prefix,
@@ -261,7 +261,6 @@ ConfigurableProxy.prototype.handle_proxy = function (kind, req, res) {
     var match = this.target_for_req(req);
     if (!match) {
         fail(req, res, 404);
-        res.write(JSON.stringify(this.routes));
         return;
     }
     var prefix = match.prefix;
@@ -316,8 +315,8 @@ ConfigurableProxy.prototype.handle_proxy_web = function (req, res) {
 ConfigurableProxy.prototype.handle_api_request = function (req, res) {
     // Handle a request to the REST API
     var args = [req, res];
-    var push_arg = function (arg) {
-        args.push(arg);
+    var push_path_arg = function (arg) {
+        args.push(arg === undefined ? arg : decodeURIComponent(arg));
     };
     for (var i = 0; i < this.api_handlers.length; i++) {
         var pat = this.api_handlers[i][0];
@@ -330,7 +329,7 @@ ConfigurableProxy.prototype.handle_api_request = function (req, res) {
                 fail(req, res, 405, "Method not supported.");
                 return;
             }
-            match.slice(1).forEach(push_arg);
+            match.slice(1).forEach(push_path_arg);
             handler.apply(handler, args);
             return;
         }

--- a/lib/trie.js
+++ b/lib/trie.js
@@ -42,6 +42,7 @@ var string_to_path = function (s) {
         return s.split('/');
     }
 };
+exports.string_to_path = string_to_path;
 
 URLTrie.prototype.add = function (path, data) {
     // add data to a node in the trie at path

--- a/test/api_spec.js
+++ b/test/api_spec.js
@@ -82,6 +82,24 @@ describe("API Tests", function () {
         });
     });
     
+    it("POST /api/routes[/foo%20bar] handles URI escapes", function (done) {
+        var port = 8998;
+        var target = 'http://127.0.0.1:' + port;
+        r.post({
+            url: api_url + '/user/foo%40bar',
+            body: JSON.stringify({target: target}),
+        }, function (error, res, body) {
+            expect(res.statusCode).toEqual(201);
+            expect(res.body).toEqual('');
+            var route = proxy.routes['/user/foo@bar'];
+            expect(route.target).toEqual(target);
+            expect(typeof route.last_activity).toEqual('object');
+            route = proxy.target_for_req({url: '/user/foo@bar/path'});
+            expect(route.target).toEqual(target);
+            done();
+        });
+    });
+    
     it("POST /api/routes creates a new root route", function (done) {
         var port = 8998;
         var target = 'http://127.0.0.1:' + port;

--- a/test/proxy_spec.js
+++ b/test/proxy_spec.js
@@ -78,6 +78,32 @@ describe("Proxy Tests", function () {
         });
     });
     
+    it("handle URI encoding", function (done) {
+        util.add_target(proxy, '/b@r/b r', test_port, false, '/foo');
+        r(proxy_url + '/b%40r/b%20r/rest/of/it', function (error, res, body) {
+            expect(res.statusCode).toEqual(200);
+            body = JSON.parse(body);
+            expect(body).toEqual(jasmine.objectContaining({
+                path: '/b@r/b r',
+                url: '/foo/b%40r/b%20r/rest/of/it'
+            }));
+            done();
+        });
+    });
+    
+    it("handle @ in URI same as %40", function (done) {
+        util.add_target(proxy, '/b@r/b r', test_port, false, '/foo');
+        r(proxy_url + '/b@r/b%20r/rest/of/it', function (error, res, body) {
+            expect(res.statusCode).toEqual(200);
+            body = JSON.parse(body);
+            expect(body).toEqual(jasmine.objectContaining({
+                path: '/b@r/b r',
+                url: '/foo/b@r/b%20r/rest/of/it'
+            }));
+            done();
+        });
+    });
+    
     it("prependPath: false prevents target path from being prepended", function (done) {
         proxy.proxy.options.prependPath = false;
         util.add_target(proxy, '/bar', test_port, false, '/foo');


### PR DESCRIPTION
- routing table contains only decoded URIs
- URIs are decoded before checking with trie