### PR TITLE
add --error-target

### DIFF
--- a/bin/configurable-http-proxy
+++ b/bin/configurable-http-proxy
@@ -25,6 +25,7 @@ args
     .option('--api-ssl-key <keyfile>', 'SSL key to use, if any, for API requests')
     .option('--api-ssl-cert <certfile>', 'SSL certificate to use, if any, for API requests')
     .option('--default-target <host>', 'Default proxy target (proto://host[:port]')
+    .option('--error-target <host>', 'Alternate server for handling proxy errors (proto://host[:port]')
     .option('--redirect-port <redirect-port>', 'Redirect HTTP requests on this port to the server on HTTPS')
     // passthrough http-proxy options
     .option('--no-x-forward', "Don't add 'X-forward-' headers to proxied requests")
@@ -74,6 +75,7 @@ if (args.apiSslKey || args.apiSslCert) {
 
 // because camelCase is the js way!
 options.default_target = args.defaultTarget;
+options.error_target = args.errorTarget;
 options.host_routing = args.hostRouting;
 options.auth_token = process.env.CONFIGPROXY_AUTH_TOKEN;
 options.redirectPort = args.redirectPort;

--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -14,8 +14,8 @@ var http = require('http'),
     httpProxy = require('http-proxy'),
     log = require('winston'),
     util = require('util'),
-    parse_url = require('url').parse,
-    parse_query = require('querystring').parse,
+    URL = require('url'),
+    querystring = require('querystring'),
     trie = require('./trie.js');
 
 function bound (that, method) {
@@ -104,6 +104,10 @@ function ConfigurableProxy (options) {
     this.includePrefix = options.includePrefix === undefined ? true : options.includePrefix;
     this.routes = {};
     this.host_routing = this.options.host_routing;
+    this.error_target = options.error_target;
+    if (this.error_target && this.error_target.slice(-1) !== '/') {
+        this.error_target = this.error_target + '/'; // ensure trailing /
+    }
 
     if (this.options.default_target) {
         this.add_route('/', {
@@ -177,10 +181,10 @@ ConfigurableProxy.prototype.remove_route = function (path) {
 ConfigurableProxy.prototype.get_routes = function (req, res) {
     // GET returns routing table as JSON dict
     var that = this;
-    var parsed = parse_url(req.url);
+    var parsed = URL.parse(req.url);
     var inactive_since = null;
     if (parsed.query) {
-        var query = parse_query(parsed.query);
+        var query = querystring.parse(parsed.query);
         if (query.hasOwnProperty('inactive_since')) {
             var timestamp = Date.parse(query.inactive_since);
             if (isFinite(timestamp)) {
@@ -255,13 +259,57 @@ ConfigurableProxy.prototype.update_last_activity = function (prefix) {
     }
 };
 
+ConfigurableProxy.prototype._handle_proxy_error_default = function (code, kind, req, res) {
+    // called when no custom error handler is registered,
+    // or is registered and doesn't work
+    if (res.writeHead) res.writeHead(code);
+    if (res.write) res.write(http.STATUS_CODES[code]);
+    if (res.end) res.end();
+};
+
+ConfigurableProxy.prototype.handle_proxy_error = function (code, kind, req, res) {
+    // called when proxy itself has an error
+    // so far, just 404 for no target and 502 for target not responding
+    // custom error server gets `/CODE?url=/escaped_url/`, e.g.
+    // /404?url=%2Fuser%2Ffoo
+    
+    log.error("%s %s %s", code, req.method, req.url);
+    if (this.error_target) {
+        var url_spec = URL.parse(this.error_target);
+        url_spec.search = '?' + querystring.encode({url: req.url});
+        url_spec.pathname = url_spec.pathname + code.toString();
+        var url = URL.format(url_spec);
+        var error_request = http.request(url, function (upstream) {
+            ['content-type', 'content-encoding'].map(function (key) {
+                if (!upstream.headers[key]) return;
+                res.setHeader(key, upstream.headers[key]);
+            });
+            if (res.writeHead) res.writeHead(code);
+            upstream.on('data', function (data) {
+                if (res.write) res.write(data);
+            });
+            upstream.on('end', function () {
+                if (res.end) res.end();
+            });
+        });
+        error_request.on('error', function(e) {
+            // custom error failed, fallback on default
+            log.error("Failed to get custom error page", e);
+            this._handle_proxy_error_default(code, kind, req, res);
+        });
+        error_request.end();
+    } else {
+        this._handle_proxy_error_default(code, kind, req, res);
+    }
+};
+
 ConfigurableProxy.prototype.handle_proxy = function (kind, req, res) {
     // proxy any request
     var that = this;
     // get the proxy target
     var match = this.target_for_req(req);
     if (!match) {
-        fail(req, res, 404);
+        this.handle_proxy_error(404, kind, req, res);
         return;
     }
     var prefix = match.prefix;
@@ -283,9 +331,7 @@ ConfigurableProxy.prototype.handle_proxy = function (kind, req, res) {
     // add error handling
     args.push(function (e) {
         log.error("Proxy error: ", e);
-        if (res.writeHead) res.writeHead(502);
-        if (res.write) res.write("Proxy target missing");
-        if (res.end) res.end();
+        that.handle_proxy_error(502, kind, req, res);
     });
     
     // update last activity timestamp in routing table
@@ -321,7 +367,7 @@ ConfigurableProxy.prototype.handle_api_request = function (req, res) {
     }
     for (var i = 0; i < this.api_handlers.length; i++) {
         var pat = this.api_handlers[i][0];
-        var match = pat.exec(parse_url(req.url).pathname);
+        var match = pat.exec(URL.parse(req.url).pathname);
         if (match) {
             var handlers = this.api_handlers[i][1];
             var handler = handlers[req.method.toLowerCase()];

--- a/lib/testutil.js
+++ b/lib/testutil.js
@@ -1,8 +1,10 @@
 "use strict";
 
 var http = require('http');
+var URL = require('url');
 var extend = require('util')._extend;
 var WebSocketServer = require('ws').Server;
+var querystring = require('querystring');
 
 var configproxy = require('../lib/configproxy');
 
@@ -57,15 +59,32 @@ exports.setup_proxy = function (port, callback, options, paths) {
     
     var ip = '127.0.0.1';
 
-    var count = 0;
+    var countdown = 2;
     var onlisten = function () {
-        count = count + 1;
-        if (count === 2) {
+        countdown = countdown - 1;
+        if (countdown === 0) {
             if (callback) {
-                callback();
+                callback(proxy);
             }
         }
     };
+    
+    if (options.error_target) {
+        countdown = countdown + 1;
+        var error_server = http.createServer(function (req, res) {
+            var parsed = URL.parse(req.url);
+            var query = querystring.parse(parsed.query);
+            res.setHeader('Content-Type', 'text/plain');
+            res.write(query.url);
+            req.on('data', function () {});
+            req.on('end', function () {
+                res.end();
+            });
+        });
+        error_server.on('listening', onlisten);
+        error_server.listen(URL.parse(options.error_target).port, ip);
+        servers.push(error_server);
+    }
     
     proxy.proxy_server.listen(port, ip);
     proxy.api_server.listen(port + 1, ip);

--- a/test/proxy_spec.js
+++ b/test/proxy_spec.js
@@ -159,6 +159,20 @@ describe("Proxy Tests", function () {
             }));
             done();
         });
-
+    });
+    
+    it("custom error target", function (done) {
+        var port = 55555;
+        util.setup_proxy(port, function (proxy) {
+            var url = 'http://127.0.0.1:' + port + '/foo/bar';
+            r(url, function (error, res, body) {
+                expect(res.statusCode).toEqual(404);
+                expect(res.headers['content-type']).toEqual('text/plain');
+                expect(body).toEqual('/foo/bar');
+                done();
+            });
+        }, {
+            error_target: 'http://127.0.0.1:55565'
+        }, []);
     });
 });


### PR DESCRIPTION
for specifying a server to use for rendering proxy error pages (errors raised in the proxy, not by proxied servers)

right now, this can only be 404 and 502

error server will receive a request of the form:

   /404?url=%2Fescaped%2Fpath

and the server should reply with an html page, which will be served to the client