### PR TITLE
Add a Swagger Spec for the API subset required by JupyterHub

### DIFF
--- a/swagger-spec.yaml
+++ b/swagger-spec.yaml
@@ -4,7 +4,14 @@ info:
   description: The REST API JupyterHub requires from a compatible Configurable HTTP Proxy implementation
   version: 0.0.1
 schemes:
-  - https
+  - http
+securityDefinitions:
+  token:
+    type: apiKey
+    name: Authorization
+    in: header
+security:
+  - token: []
 basePath: /api/routes
 produces:
   - application/json

--- a/swagger-spec.yaml
+++ b/swagger-spec.yaml
@@ -1,0 +1,70 @@
+swagger: '2.0'
+info:
+  title: Configurable HTTP Proxy (Jupyter requirements)
+  description: The REST API JupyterHub requires from a compatible Configurable HTTP Proxy implementation
+  version: 0.0.1
+schemes:
+  - https
+basePath: /api/routes
+produces:
+  - application/json
+paths:
+  /:
+    get:
+      summary: All routes
+      description: All routes currently in the proxy's routing table, excluding the default route
+      parameters:
+        - name: inactive_since
+          in: query
+          description: Only return routes with last_activity before this time
+          required: false
+          type: string
+          format: ISO8601 Timestamp
+      responses:
+        '200':
+          description: The routing table
+          schema:
+              $ref: '#/definitions/RoutingTable'
+  /{path_prefix}:
+    post:
+      summary: Create a new route
+      parameters:
+        - name: path_prefix
+          description: Path prefix to match to route to this target
+          in: path
+          required: true
+          type: string
+          format: Path
+      responses:
+        '201':
+          description: Successfully created
+    delete:
+      summary: Delete the given route
+      parameters:
+        - name: path_prefix
+          in: path
+          required: true
+          type: string
+          format: Path
+      responses:
+        '204':
+          description: Successfully deleted
+definitions:
+  RoutingTable:
+    type: object
+    description: Maps keys (route path prefixes) to their targets
+    additionalProperties:
+      $ref: '#/definitions/RouteTarget'
+  RouteTarget:
+    type: object
+    properties:
+      target:
+        type: string
+        format: URI
+        description: 'Fully qualified URL that will be the target of proxied
+          requests that match this route'
+      last_activity:
+        type: string
+        format: ISO8601 Timestamp
+        readOnly: true
+        description: ISO8601 Timestamp of when this route was last used to route a request

--- a/swagger-spec.yaml
+++ b/swagger-spec.yaml
@@ -1,7 +1,7 @@
 swagger: '2.0'
 info:
-  title: Configurable HTTP Proxy (Jupyter requirements)
-  description: The REST API JupyterHub requires from a compatible Configurable HTTP Proxy implementation
+  title: Configurable HTTP Proxy
+  description: The REST API for configurable-http-proxy.
   version: 0.0.1
 schemes:
   - http
@@ -32,34 +32,40 @@ paths:
           description: The routing table
           schema:
               $ref: '#/definitions/RoutingTable'
-  /{path_prefix}:
+  /{route_spec}:
     post:
       summary: Create a new route
       parameters:
-        - name: path_prefix
-          description: Path prefix to match to route to this target
+        - name: route_spec
+          description: Route specification to create - a path prefix if the proxy is in path mode (default) or '/' followed by hostname if it is in host mode.
           in: path
           required: true
           type: string
           format: Path
+        - name: body
+          in: body
+          schema:
+            $ref: '#/definitions/RouteTarget'
+          required: true
       responses:
         '201':
           description: Successfully created
     delete:
       summary: Delete the given route
       parameters:
-        - name: path_prefix
+        - name: route_spec
           in: path
           required: true
           type: string
           format: Path
+          description: Route specification to create - a path prefix if the proxy is in path mode (default) or '/' followed by hostname if it is in host mode.
       responses:
         '204':
           description: Successfully deleted
 definitions:
   RoutingTable:
     type: object
-    description: Maps keys (route path prefixes) to their targets
+    description: Maps keys (route path prefixes / hostnames) to their targets
     additionalProperties:
       $ref: '#/definitions/RouteTarget'
   RouteTarget:


### PR DESCRIPTION
Fixes #39 

Not sure exactly if this belongs here - it's only the subset that's strictly required for jupyterhub
to work properly.