### PR TITLE
add ConfigProxy.proxy_request event

### DIFF
--- a/lib/configproxy.js
+++ b/lib/configproxy.js
@@ -13,6 +13,7 @@ var http = require('http'),
     https = require('https'),
     fs = require('fs'),
     path = require('path'),
+    EventEmitter = require('events').EventEmitter,
     httpProxy = require('http-proxy'),
     log = require('winston'),
     util = require('util'),
@@ -161,6 +162,8 @@ function ConfigurableProxy (options) {
     // proxy websockets
     this.proxy_server.on('upgrade', bound(this, this.handle_proxy_ws));
 }
+
+util.inherits(ConfigurableProxy, EventEmitter);
 
 ConfigurableProxy.prototype.add_route = function (path, data) {
     // add a route to the routing table
@@ -337,6 +340,7 @@ ConfigurableProxy.prototype.handle_proxy = function (kind, req, res) {
         this.handle_proxy_error(404, kind, req, res);
         return;
     }
+    this.emit("proxy_request", req, res);
     var prefix = match.prefix;
     var target = match.target;
     log.debug("PROXY", kind.toUpperCase(), req.url, "to", target);

--- a/lib/testutil.js
+++ b/lib/testutil.js
@@ -24,6 +24,7 @@ var add_target = exports.add_target = function (proxy, path, port, websocket, ta
     server = http.createServer(function (req, res) {
         var reply = extend({}, data);
         reply.url = req.url;
+        reply.headers = req.headers;
         res.write(JSON.stringify(reply));
         res.end();
     });

--- a/test/proxy_spec.js
+++ b/test/proxy_spec.js
@@ -66,6 +66,28 @@ describe("Proxy Tests", function () {
         });
     });
     
+    it("proxy_request event can modify headers", function (done) {
+        var called = {};
+        proxy.on('proxy_request', function (req, res) {
+            req.headers.testing = 'Test Passed';
+            called.proxy_request = true;
+        });
+        
+        r(proxy_url, function (error, res, body) {
+            expect(res.statusCode).toEqual(200);
+            body = JSON.parse(body);
+            expect(called.proxy_request).toBe(true);
+            expect(body).toEqual(jasmine.objectContaining({
+                path: '/',
+            }));
+            expect(body.headers).toEqual(jasmine.objectContaining({
+                testing: 'Test Passed',
+            }));
+            
+            done();
+        });
+    });
+    
     it("target path is prepended by default", function (done) {
         util.add_target(proxy, '/bar', test_port, false, '/foo');
         r(proxy_url + '/bar/rest/of/it', function (error, res, body) {


### PR DESCRIPTION
and make ConfigProxy an EventEmitter along the way.

Callers may modify the request on its way to upstream by registering a listener on this event

cc @grantlouisherman